### PR TITLE
Run GPU test only on workflow dispatch

### DIFF
--- a/.github/workflows/ci_test_gpu.yml
+++ b/.github/workflows/ci_test_gpu.yml
@@ -1,10 +1,6 @@
 name: CI Test GPU
 
 on:
-  push:
-    branches: [ main, ]
-  pull_request:
-    branches: [ '*', ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This allow us to run when we want (when we have the self hosted runner up) without having to suffer an ugly red X all the time